### PR TITLE
Add required bupaverse packages to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,13 @@ Imports:
 	rlang, 
 	eventdataR (>= 0.2.0),
 	stringr,
-	lubridate
+	lubridate,
+	edeaR,
+	eventdataR,
+	processmapR,
+	xesreadR,
+	processmonitR,
+	petrinetR
 URL: https://www.bupar.net, https://github.com/bupaverse/bupaR
 Suggests: 
 	testthat


### PR DESCRIPTION
When doing the regular

    install.packages("bupaR")
    library(bupaR)

i got several warnings about other (required) packages not being installed on my system.